### PR TITLE
Add statistics method to character

### DIFF
--- a/README.md
+++ b/README.md
@@ -135,6 +135,7 @@ bnet.wow.character.guild({
   * [Quests](#wow-character-quests)
   * [Reputation](#wow-character-reputation)
   * [Stats](#wow-character-stats)
+  * [Statistics](#wow-character-statistics)
   * [Talents](#wow-character-talents)
   * [Titles](#wow-character-titles)
 * [Data Resources](#wow-data)
@@ -530,12 +531,23 @@ bnet.wow.character.reputation({origin: 'us', realm: 'amanthul', name: 'charni'},
 <a name="wow-character-stats"></a>
 #### Stats
 
-Returns the statistics data of the character.
+Returns the stats data of the character.
 
 *Usage*
 
 ```javascript
 bnet.wow.character.stats({origin: 'us', realm: 'amanthul', name: 'charni'}, callback);
+```
+
+<a name="wow-character-statistics"></a>
+#### Statistics
+
+Returns the statistics data of the character.
+
+*Usage*
+
+```javascript
+bnet.wow.character.statistics({origin: 'us', realm: 'amanthul', name: 'charni'}, callback);
 ```
 
 <a name="wow-character-talents"></a>

--- a/lib/wow/character.js
+++ b/lib/wow/character.js
@@ -99,6 +99,12 @@ module.exports = function(battlenet) {
       character(args.params, args.config, args.callback);
     },
 
+    statistics: function() {
+      var args = battlenet.args.apply(null, arguments);
+      args.params.fields = ['statistics'];
+      character(args.params, args.config, args.callback);
+    },
+
     talents: function() {
       var args = battlenet.args.apply(null, arguments);
       args.params.fields = ['talents'];


### PR DESCRIPTION
This branch adds the ability to pull a characters "statistics" data. The statistics data includes data such as "total killing blows". You currently have stats documented as statistics. The stats which you are currently supporting includes characters stats such as agility, str, stamina, etc. 

I was going to link you the endpoint on dev.battle.net, but at this time it appears that the endpoint is not documented there.