### PR TITLE
Include response in callback after api calls.

### DIFF
--- a/lib/core.js
+++ b/lib/core.js
@@ -122,7 +122,7 @@ module.exports = function(request, extend, options) {
 
       if (typeof callback === 'function') {
         request(req, function(err, res, body) {
-          callback(err, body);
+          callback(err, body, res);
         });
       }
     }


### PR DESCRIPTION
Current implementation doesn't allow users to get the statusCode or other response information from requests made to the api.

Adding the response as the third parameter returned allows a user of the api to determine if the response they received was a 404, 500, etc and figure out what to do based on that information.